### PR TITLE
force to set ROS_MAVEN_DEPLOYMENT_REPOSITORY to catkin devel space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install: # Use this to install any prerequisites or dependencies necessary to ru
   - find -L src -name package.xml -exec dirname {} \; | xargs -n 1 -i find {} -name manifest.xml | xargs -n 1 -i mv {} {}.deprecated
   - rosdep install -r -n --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
   - find -L src -name manifest.xml.deprecated | xargs -n 1 -i dirname {} | xargs -n 1 -i ln -sf `pwd`/{}/manifest.xml.deprecated `pwd`/{}/manifest.xml
-  - if [ $BUILDER = rosbuild ]; then source src/setup.sh; fi
+  - if [ $BUILDER = rosbuild ]; then source src/setup.sh; rosdep install -r -n --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y; fi
   - if [ $ROS_DISTRO = groovy ]; then sudo apt-get install ros-$ROS_DISTRO-visualization-msgs ros-$ROS_DISTRO-common-tutorials ros-$ROS_DISTRO-navigation ros-$ROS_DISTRO-audio-common; fi
 before_script: # Use this to prepare your build for testing e.g. copy database configurations, environment variables, etc.
   - source /opt/ros/$ROS_DISTRO/setup.bash


### PR DESCRIPTION
in jsk_rosjava_message package, force to set `ROS_MAVEN_DEPLOYMENT_REPOSITORY`
environment variable to point to catkin devel space.

because that environment variable is sometimes set to wrong read-only directory such as `/opt/ros/hydro/share/...`.

see https://github.com/jsk-ros-pkg/jsk_smart_apps/issues/13 
