### PR TITLE
[jsk_android_gui_api9/cameras_and_points_mux.launch] use env ROBOT for including machine tags

### DIFF
--- a/jsk_android_gui_api9/cameras_and_points_mux.launch
+++ b/jsk_android_gui_api9/cameras_and_points_mux.launch
@@ -1,8 +1,9 @@
 <launch>
+  <arg name="ROBOT" default="$(env ROBOT)" />
   <arg name="USE_NODELET" default="false" />
   <arg name="POINTS_NODELET_MANAGER" default="/kinect_head/openni_nodelet_manager" />
   <arg name="IMAGE_NODELET_MANAGER" default="/kinect_head/openni_nodelet_manager" />
-  <include file="$(find pr2_machine)/pr2.machine" />
+  <include file="$(find pr2_machine)/$(arg ROBOT).machine" />
   <group unless="$(arg USE_NODELET)">
     <node pkg="topic_tools" type="mux" output="screen"
           name="mux_for_image" respawn="true"


### PR DESCRIPTION
This is necessary for launching with pr2_gazebo